### PR TITLE
Fix: varying truncating dots styles of UILabel

### DIFF
--- a/Groove/Data/Playlists.plist
+++ b/Groove/Data/Playlists.plist
@@ -1009,32 +1009,32 @@
 		<array>
 			<dict>
 				<key>title</key>
-				<string>숲에 불 켜졌다
-오늘모임은 고민회 오늘 모임은 고민회</string>
+				<string>숲에 불 켜졌다 
+오늘 모임은 고민회 아아- 모두 집합!</string>
 			</dict>
 			<dict>
 				<key>title</key>
-				<string>미친 텐션
-쉴틈없는 수다 폭탄 w.유키스</string>
+				<string>김해준 in 
+야간합주실 with 암호준 야간 합주실</string>
 			</dict>
 			<dict>
 				<key>title</key>
-				<string>오늘은 찐으로 누워서 이불킥킥킥!! 오늘은 찐으로 누워서 이불킥킥킥!!</string>
+				<string>오늘은 찐으로 누워서 이불킥킥킥!! 오늘은 찐으 로 누워서 이불킥킥킥!!</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>생방 보쇼!
-더 신나게 개편된 누리끼리 생방 보쇼!</string>
+더 신나게 개편된 누리끼 리 생방 보쇼!</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>오왠의 신곡
-&apos;난 당신의 고요함이&apos; 비하인드 스토리 비하인드 스토리</string>
+&apos;난 당신의 고요함이&apos; 비 하인드 스토리 비하인드 스토리</string>
 			</dict>
 			<dict>
 				<key>title</key>
 				<string>쌔굿바..
-마지막 항마랜드 늦지 않게 탑승 마지막 항마랜드 늦지 않게 탑승</string>
+마지막 항마랜드 늦지 않 게 탑승 마지막 항마랜드 늦지 않게 탑승</string>
 			</dict>
 			<dict>
 				<key>title</key>
@@ -1044,7 +1044,15 @@
 			<dict>
 				<key>title</key>
 				<string>어? 스며들었다
-날 설레게한 모든 것 점심어택 날 설레게 한 모든 것</string>
+날 설레게한 모든 것 점심 어택 날 설레게 한 모든 것</string>
+			</dict>
+			<dict>
+				<key>title</key>
+				<string>A string that automatically wraps into 2 lines in English</string>
+			</dict>
+			<dict>
+				<key>title</key>
+				<string>Astringthatautomaticallywrapsinto2lines inEnglish</string>
 			</dict>
 		</array>
 	</dict>


### PR DESCRIPTION
UILabel 은 내부의 텍스트 내용이 UILabel의 사이즈보다 긴 경우에는 뒤에 `...` 를 붙여 내용을 자동으로 truncate 시키도록 되어있다.

그런데 어떤 cell의 텍스트는 `...`로 truncate이 되어있었고, 또 다른 cell의 텍스트는 ⋯ 로 truncate 되어 있었다. (아래 이미지 참고)

<br>

<img src="https://i.stack.imgur.com/8zh5j.png" width="400">


해당 문제의 원인을 찾고자 스택오버플로우에 처음으로 질문을 올려보기도 했다.
https://stackoverflow.com/questions/66165378/how-can-i-standardize-the-the-varying-truncating-dot-characters-of-uilabel

UILabel에 텍스트를 할당하는 것에는 차이점이 없고 특별한 로직이 없기에 문자열 데이터의 형태에 따라 해당 문제가 발생하는 것으로 추측했다.

수많은 시행 착오 끝에 문제의 원인을 발견할 수 있었다. truncate 시키는 위치에 한글 문자가 연속적으로 있을 경우에는 `...`가 아닌  ⋯ 로 표시한다는 것이다.

<img src="https://user-images.githubusercontent.com/46217844/107775492-ae755300-6d83-11eb-9385-840553f032ca.png" width="600">

클론 하고자 하는 앱은 이에 대해 코드로 character 숫자가 어느 기준 이상으로 되면 ... 를 붙여주거나 하여 truncate 시키는 부분을 일관되도록 적용해준 것으로 보인다. 

현재는 plist 파일에 해당 데이터에서 truncate 되는 부분을 찾아 whitespace를 더하여 truncating character이 `...`로 일관되도록 변경하였다.
